### PR TITLE
Fix maven-release plugin version to 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,15 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>


### PR DESCRIPTION
There are issues with Maven release plugin 2.5.1:
    mvn release:prepare && man release:perform
update POM and commit changes in a wrong order. 2.5 is the last working
version.
